### PR TITLE
Rename attributes on FadingTextView #27

### DIFF
--- a/app/src/main/res/layout/content_main.xml
+++ b/app/src/main/res/layout/content_main.xml
@@ -21,9 +21,9 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center"
-        app:texts="@array/examples"
-        app:shuffle="true"
-        app:timeout="500" />
+        app:fadingTextViewTexts="@array/examples"
+        app:fadingTextViewShuffle="true"
+        app:fadingTextViewTimeout="500" />
 
     <org.adw.library.widgets.discreteseekbar.DiscreteSeekBar
         android:id="@+id/timeout_bar"

--- a/fadingtextview/src/main/java/com/tomer/fadingtextview/FadingTextView.kt
+++ b/fadingtextview/src/main/java/com/tomer/fadingtextview/FadingTextView.kt
@@ -110,12 +110,12 @@ class FadingTextView @JvmOverloads constructor(
             val typedArray =
                 context.obtainStyledAttributes(attributeSet, R.styleable.FadingTextView)
 
-            typedArray.getTextArray(R.styleable.FadingTextView_texts)?.let { textArray ->
+            typedArray.getTextArray(R.styleable.FadingTextView_fadingTextViewTexts)?.let { textArray ->
                 texts = textArray
             }
 
             val baseTimeout = typedArray.getInteger(
-                R.styleable.FadingTextView_timeout,
+                R.styleable.FadingTextView_fadingTextViewTimeout,
                 DEFAULT_TIME_OUT.toInt(DurationUnit.MILLISECONDS)
             ).milliseconds
             val animationDuration =
@@ -123,7 +123,7 @@ class FadingTextView @JvmOverloads constructor(
 
             timeout = baseTimeout + animationDuration
 
-            typedArray.getBoolean(R.styleable.FadingTextView_shuffle, false).also { shouldShuffle ->
+            typedArray.getBoolean(R.styleable.FadingTextView_fadingTextViewShuffle, false).also { shouldShuffle ->
                 if (shouldShuffle) {
                     shuffle()
                 }
@@ -193,6 +193,7 @@ class FadingTextView @JvmOverloads constructor(
      * Sets the length of time to wait between text changes in specific time units
      *
      * @param timeout  The duration to wait between text changes
+     * @throws IllegalArgumentException if the duration is not positive.
      */
     fun setTimeout(timeout: Duration) {
         require(timeout.isPositive()) { "Timeout must be longer than 0" }

--- a/fadingtextview/src/main/res/values/attrs.xml
+++ b/fadingtextview/src/main/res/values/attrs.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="FadingTextView">
-        <attr name="texts" format="reference" />
-        <attr name="timeout" format="integer"/>
-        <attr name="shuffle" format="boolean" />
+        <attr name="fadingTextViewTexts" format="reference" />
+        <attr name="fadingTextViewTimeout" format="integer"/>
+        <attr name="fadingTextViewShuffle" format="boolean" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
The attributes were renamed to be more specific to avoid conflicts and potential conflicts with other libraries.